### PR TITLE
Remove _config_local.yml from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ ehthumbs.db
 ## Config file to test locally ##
 # Run as:
 # bundle exec jekyll serve --livereload --config _config_local.yml
-_config_local.yml
+#_config_local.yml


### PR DESCRIPTION
We want people to have access to this file so that they can run jekyll
on it. In that way, when testing locally, they don't have to change 
the _config.yml file that is used in the live website.