### PR TITLE
Add foldable panes into main webpages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ gems:
 safe: false
 
 # Build Settings
+excerpt_separator: <!--more-->
 markdown: kramdown
 permalink: pretty
 exclude: ['/automation/', 'README.md', 'LICENSE.txt', 'CNAME']

--- a/_config_local.yml
+++ b/_config_local.yml
@@ -4,6 +4,7 @@ gems:
 safe: false
 
 # Build Settings
+excerpt_separator: <!--more-->
 markdown: kramdown
 permalink: pretty
 exclude: ['/automation/', 'README.md', 'LICENSE.txt', 'CNAME']

--- a/_data/accordion.yml
+++ b/_data/accordion.yml
@@ -1,0 +1,7 @@
+subspace:
+  - title: Resources
+    url: subspace/resources.html         
+    id: resources
+  - title: Virtual Talks
+    url: subspace/talks.html
+    id: talks

--- a/_includes/accordion.html
+++ b/_includes/accordion.html
@@ -1,0 +1,36 @@
+<div class="accordion" id="accordionExample">
+  {% for section in site.data.accordion[page.subfolder] %}
+  <div class="card">
+    <div class="card-header" id="headingOne">
+      <h2 class="mb-0">
+        <button class="btn btn-link btn-block text-left" type="button"
+							 data-toggle="collapse"
+	data-target="#{{ section.id }}"
+		aria-expanded="false" aria-controls="collapseOne">
+	{{ section.title}}
+
+        </button>
+      </h2>
+    </div>
+   <div id="{{ section.id }}" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+      <div class="card-body">
+      <li>
+      <a href="{{ section.url }}">{{ section.title }}</a>
+        {% capture full_id %}
+	  /{{ page.collection }}/{{ page.subfolder }}/{{ section.id }}
+        {% endcapture %}
+
+	{% assign target_collection = site.collections | where: "label",
+	page.collection | first %}
+	{% for node in target_collection.docs %}
+	  {% if full_id contains node.id %}
+	    {{ node.excerpt }}
+	  {% endif %}
+	{% endfor %}
+
+      </li>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>

--- a/_study-groups/multivariate-blind-subspace.md
+++ b/_study-groups/multivariate-blind-subspace.md
@@ -4,10 +4,12 @@ title: "#BSIsubspace Section"
 # leader ID = speaker ID - 1
 leader: 7
 image: banner_BSI_groups.jpg
+subfolder: subspace
 ---
 
 A (sub)space to discuss and learn about the relationships among classical & novel multivariate and subspace analysis methods 🤓
 
+{% include accordion.html %}
 
 #### List of Resources
 ![]({{ site.baseurl }}/img/subspace-updates/UsefulResources_part1.png)

--- a/_study-groups/subspace/resources.md
+++ b/_study-groups/subspace/resources.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: "Resources section in the subspace group"
+---
+
+sdasdasdsadasdasdasd
+asdasdasdddddddddasd
+dasdarfgdfgdfgfdgdfg
+<!--more-->
+jajajajajajajajajaja
+
+
+#### List of Resources
+![]({{ site.baseurl }}/img/subspace-updates/UsefulResources_part1.png)
+
+
+

--- a/_study-groups/subspace/talks.md
+++ b/_study-groups/subspace/talks.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Talks in the subspace group"
+---
+
+### Virtual talks
+##### 2021
+[![]({{ site.baseurl }}/img/subspace-updates/Virtual_Talks_Info.png)](https://www.youtube.com/playlist?list=PLADTemYh-7P3ih6KDbhvLEzsGnYcoez_x)


### PR DESCRIPTION
This adapts and extends the Boostrap accordion [example](https://getbootstrap.com/docs/4.6/components/collapse/#accordion-example) to have foldable sections in the main webpages of the study groups. This could be used to structure and organize content into subpages. The main files and structure:

_data/accordion.yml:
Each mapping (e.g., subspace) represents a main page (e.g., the main page for the multivariate subspace [group](https://brainspaceinitiative.github.io/study-groups/multivariate-blind-subspace)). For each mapping, one can add one block per subpage (e.g., the 'resources' page for the subspace group). There are three fields on each block: 'title', 'url', and 'id'. These fields are to be used in the accordion template to generate the foldable sections.

_includes/accordion.html:
This contains the Boostrap code and Liquid/Jekyll code to build the foldable panes using the data from accordion.yml and attributes from the variables `page` and `site`.

In the page where the template accordion.html is used, one must define a `shortid` variable in the front matter indicating which mapping in accordion.yml will be used. The subspages has to be named as `<id>.md`, where `<id>` is the corresponding `id` field in the accordion.yml file. Also, this subpages have to be stored in a subfolder called `<shortid>`, inside the _study-groups folder.

In the foldable panes, a preview or excerpt of each subpage will be presented. By default, the first paragraph is displayed, but one can control how much to show by adding `<!--more-->` at the point in the subpage where one wants to stop the preview.